### PR TITLE
Use getframe instead of stack

### DIFF
--- a/depocs/__init__.py
+++ b/depocs/__init__.py
@@ -240,7 +240,7 @@ class Scoped(ScopedClass("ScopedBase", (object,), {})):
         self._Scoped__is_used = True
 
         try:
-            frame = sys._getframe(call_site_level - 1)
+            frame = sys._getframe(call_site_level)
         except ValueError:
             # No frame found, skip
             pass
@@ -291,7 +291,7 @@ class Scoped(ScopedClass("ScopedBase", (object,), {})):
         return self._Scoped__is_open
 
     @property
-    def open_site(self):
+    def open_site(self) -> inspect.Traceback:
         return inspect.getframeinfo(self._Scoped__open_site_frame)
 
     @property
@@ -355,7 +355,7 @@ class Scoped(ScopedClass("ScopedBase", (object,), {})):
     def format_trace_entry(self):
         if self.open_site:
             return "{0}({1}) opened at {2}:{3}\n".format(
-                self.__class__.__name__, id(self), self.open_site[1], self.open_site[2]
+                self.__class__.__name__, id(self), self.open_site[0], self.open_site[1]
             )
         else:
             return "{0}({1}) opened somewhere\n".format(

--- a/depocs/__init__.py
+++ b/depocs/__init__.py
@@ -240,12 +240,10 @@ class Scoped(ScopedClass("ScopedBase", (object,), {})):
         self._Scoped__is_used = True
 
         try:
-            frame = sys._getframe(call_site_level)
+            self._Scoped__open_site_frame = sys._getframe(call_site_level)
         except ValueError:
             # No frame found, skip
             pass
-        else:
-            self._Scoped__open_site_frame = frame
 
         return self
 

--- a/depocs/__init__.py
+++ b/depocs/__init__.py
@@ -11,6 +11,7 @@ provides very informative error messages when you do something wrong.
 """
 
 import inspect
+import sys
 import threading
 
 
@@ -196,7 +197,7 @@ class Scoped(ScopedClass("ScopedBase", (object,), {})):
 
     _Scoped__is_open = False
     _Scoped__is_used = False
-    _Scoped__open_site = None
+    _Scoped__open_site_frame = None
 
     def open(self, call_site_level=1):
         """
@@ -238,9 +239,13 @@ class Scoped(ScopedClass("ScopedBase", (object,), {})):
         self._Scoped__is_open = True
         self._Scoped__is_used = True
 
-        stack = inspect.stack()
-        if len(stack) > call_site_level:
-            self._Scoped__open_site = stack[call_site_level]
+        try:
+            frame = sys._getframe(call_site_level - 1)
+        except ValueError:
+            # No frame found, skip
+            pass
+        else:
+            self._Scoped__open_site_frame = frame
 
         return self
 
@@ -287,7 +292,7 @@ class Scoped(ScopedClass("ScopedBase", (object,), {})):
 
     @property
     def open_site(self):
-        return self._Scoped__open_site
+        return inspect.getframeinfo(self._Scoped__open_site_frame)
 
     @property
     def is_used(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "depocs"
-version = "2.0.0.dev1"
+version = "2.1.0"
 homepage = "https://github.com/sdelements/depocs"
 description = "Scoped thread-local mixin class"
 authors = ["Security Compass <contact@securitycompass.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "depocs"
-version = "2.0.0"
+version = "2.0.0.dev1"
 homepage = "https://github.com/sdelements/depocs"
 description = "Scoped thread-local mixin class"
 authors = ["Security Compass <contact@securitycompass.com>"]


### PR DESCRIPTION
The `inspect.stack` call is rather expensive and makes opening multiple contexts in a sequence rather expensive. Since we only need to grab a specific frame from the stack, we can opt for using getframe instead of fetching the entire stack.